### PR TITLE
Install all headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,8 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cadmesh-config.cmake.in" "${CM
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cadmesh-config.cmake" DESTINATION "lib/cmake/cadmesh-${CADMESH_MAJOR_VERSION}.${CADMESH_MINOR_VERSION}.${CADMESH_PATCH_VERSION}")
 
 # Install the CADMesh headers and library.
-install(FILES ${PROJECT_SOURCE_DIR}/include/CADMesh.hh DESTINATION include)
-install(FILES ${PROJECT_BINARY_DIR}/include/Configuration.hh DESTINATION include)
+install(FILES ${headers} DESTINATION include/CADMesh)
+install(FILES ${PROJECT_BINARY_DIR}/include/Configuration.hh DESTINATION include/CADMesh)
 install(TARGETS cadmesh DESTINATION lib)
 
 # Set CPack to build an archive.

--- a/cmake/cadmesh-config.cmake.in
+++ b/cmake/cadmesh-config.cmake.in
@@ -1,4 +1,4 @@
 
-set(CADMESH_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include)
+set(CADMESH_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include/CADMesh)
 set(cadmesh_LIBRARIES -L@CMAKE_INSTALL_PREFIX@/lib cadmesh assimp tet)
 


### PR DESCRIPTION

Install all headers in cmake build
```
mkdir build
cd build
cmake ../
make
make install
```
Put headers into their own sub folder, so that headers will not conflict if users install the into /usr/local

>>>
```
[100%] Built target cadmesh
Install the project...
-- Install configuration: "Release"
-- Up-to-date: /usr/local/lib/cmake/cadmesh-2.0.0/cadmesh-config.cmake
-- Up-to-date: /usr/local/include/CADMesh/ASSIMPReader.hh
-- Up-to-date: /usr/local/include/CADMesh/BuiltInReader.hh
-- Up-to-date: /usr/local/include/CADMesh/CADMesh.hh
-- Up-to-date: /usr/local/include/CADMesh/CADMeshTemplate.hh
-- Up-to-date: /usr/local/include/CADMesh/Exceptions.hh
-- Up-to-date: /usr/local/include/CADMesh/FileTypes.hh
-- Up-to-date: /usr/local/include/CADMesh/Lexer.hh
-- Up-to-date: /usr/local/include/CADMesh/LexerMacros.hh
-- Up-to-date: /usr/local/include/CADMesh/Mesh.hh
-- Up-to-date: /usr/local/include/CADMesh/OBJReader.hh
-- Up-to-date: /usr/local/include/CADMesh/PLYReader.hh
-- Up-to-date: /usr/local/include/CADMesh/Reader.hh
-- Up-to-date: /usr/local/include/CADMesh/STLReader.hh
-- Up-to-date: /usr/local/include/CADMesh/TessellatedMesh.hh
-- Up-to-date: /usr/local/include/CADMesh/TetrahedralMesh.hh
-- Up-to-date: /usr/local/include/CADMesh/Configuration.hh
-- Up-to-date: /usr/local/lib/libcadmesh.so
```
>>>

I have also updated the generated cmake file so that CADMESH_INCLUDE_DIRS points to include/CADMesh so users shouldn't need to change anything after this update